### PR TITLE
CSUB-384: Release binary artifacts on git tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: Build Release Artifacts
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build-binary:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        override: true
+
+    - name: Figure out tag name
+      shell: bash
+      run: |
+        TAG_NAME=$(git describe --tag)
+        echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
+
+    - name: DEBUG
+      shell: bash
+      run: |
+        echo "Tag is '${{ env.TAG_NAME }}'"
+
+    - name: Build
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --release
+
+    - name: Upload binary
+      uses: actions/upload-artifact@v3
+      with:
+        path: 'target/release/creditcoin-fork'
+        if-no-files-found: error
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs:
+      - build-binary
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Figure out tag name
+        shell: bash
+        run: |
+          TAG_NAME=$(git describe --tag)
+          echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
+
+      - name: Download binaries
+        uses: actions/download-artifact@v3
+
+      - name: DEBUG
+        shell: bash
+        run: |
+          ls -lR
+
+      - name: Make the release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: 'artifact/creditcoin-*'
+          fail_on_unmatched_files: true
+          name: ${{ env.TAG_NAME }}


### PR DESCRIPTION
These will be used later for testing purposes instead of building them every time. It will help speed-up the execution time.