### PR TITLE
CSUB-384: Use Ubuntu 20.04 which is used for creditcoin-node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   check:
     name: cargo check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -25,7 +25,7 @@ jobs:
       - run: cargo check
   fmt:
     name: check formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -34,7 +34,7 @@ jobs:
       - run: cargo fmt -- --check
   clippy:
     name: cargo clippy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-binary:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v3
@@ -45,7 +45,7 @@ jobs:
         if-no-files-found: error
 
   create-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - build-binary
     steps:


### PR DESCRIPTION
otherwise we get libc version mismatches when trying to execute the binary.

Ubntu 20.04 also used for self-hosted GitHub runners, so easier to change here!