### PR TITLE
chore: upgrade Ubuntu runners to 26.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   check:
     name: cargo check
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
     steps:
@@ -34,7 +34,7 @@ jobs:
       - run: cargo check
   fmt:
     name: check formatting
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v3
 
@@ -54,7 +54,7 @@ jobs:
       - run: cargo fmt -- --check
   clippy:
     name: cargo clippy
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-binary:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     steps:
     - uses: actions/checkout@v3
@@ -51,7 +51,7 @@ jobs:
         if-no-files-found: error
 
   create-release:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     needs:
       - build-binary
     steps:

--- a/src/main.rs
+++ b/src/main.rs
@@ -302,7 +302,7 @@ async fn main() -> Result<()> {
         .name
         .unwrap_or_else(|| orig_spec.name.joined_with("-fork"));
     spec.id = cli.id.unwrap_or_else(|| orig_spec.id.joined_with("-fork"));
-    spec.protocol_id = orig_spec.protocol_id.clone();
+    spec.protocol_id.clone_from(&orig_spec.protocol_id);
 
     let mut excludes: HashSet<&str> = if cli.no_default_excludes {
         HashSet::default()


### PR DESCRIPTION
Bumps all GitHub Actions runners from `ubuntu-24.04` to `ubuntu-26.04`.

## Changes
- `.github/workflows/ci.yml` — check, fmt, clippy jobs
- `.github/workflows/release.yml` — build-binary, create-release jobs

Requested by @atodorov via Slack (#protocol-cc3).